### PR TITLE
Add PermissionDeniedException for code 181 (Operation without permission)

### DIFF
--- a/franklinwh/client.py
+++ b/franklinwh/client.py
@@ -406,6 +406,10 @@ class InvalidDataException(Exception):
     """raised when the API returns data that is structurally invalid"""
 
 
+class PermissionDeniedException(Exception):
+    """raised when the API returns code 181 (Operation without permission), typically when polling for an optional accessory (Smart Circuit, V2L) that is not provisioned on the account."""
+
+
 class HttpClientFactory:
     """Factory to create AsyncClient."""
 
@@ -773,6 +777,8 @@ class Client(HttpClientFactory):
             raise DeviceTimeoutException(res["message"])
         if res["code"] == 136:
             raise GatewayOfflineException(res["message"])
+        if res["code"] == 181:
+            raise PermissionDeniedException(res["message"])
         assert res["code"] == 200, f"{res['code']}: {res['message']}"
         return res
 


### PR DESCRIPTION
Smallest-shape fix for #38, following the direction you suggested in the comment.

## Change

Adds `PermissionDeniedException` alongside the existing typed exceptions, and raises it from `_mqtt_send` when the API returns code `181`. The bare assert is left in place as a backstop for genuinely unknown codes.

```diff
+class PermissionDeniedException(Exception):
+    """raised when the API returns code 181 (Operation without permission), ..."""

         if res["code"] == 136:
             raise GatewayOfflineException(res["message"])
+        if res["code"] == 181:
+            raise PermissionDeniedException(res["message"])
         assert res["code"] == 200, f"{res['code']}: {res['message']}"
```

Follow-up on the integration side (separate PR) would be a one-line `except franklinwh.client.PermissionDeniedException` clause matching the existing chain in `homeassistant-franklinwh/sensor.py`. With that in place plus `tolerate_stale_data`, transient 181s stop tanking the whole coordinator.

## Answer to your question about duration

Pulled the recorder history. Each event is a single failed poll cycle that recovers on the next one:

- Event 1: sensors went unavailable at `14:48:46Z`, came back with same prior values at `14:49:52Z` → 66 seconds
- Event 2: unavailable at `03:53:44Z`, back at `03:54:16Z` → 32 seconds

So the condition itself is short. The two events in my 24h window were ~13 hours apart, not at the same wall-clock time, so probably not a cron, more likely an intermittent backend hiccup whenever it's evaluating accessory authorization.

## Test

Imported the module and round-tripped a raise/catch on the new exception locally. Happy to add a unit test if you'd prefer one alongside `caching_thread_test.py`.