### PR TITLE
Read currendId, oldIndex and stromEn from the gateway instead of hardcoding them

### DIFF
--- a/franklinwh/client.py
+++ b/franklinwh/client.py
@@ -221,6 +221,13 @@ MODE_TIME_OF_USE = "time_of_use"
 MODE_SELF_CONSUMPTION = "self_consumption"
 MODE_EMERGENCY_BACKUP = "emergency_backup"
 
+# workMode is the stable enum; the profile *ids* alongside it are per-account.
+WORK_MODE_TO_NAME = {
+    1: MODE_TIME_OF_USE,
+    2: MODE_SELF_CONSUMPTION,
+    3: MODE_EMERGENCY_BACKUP,
+}
+
 MODE_MAP = {
     9322: MODE_TIME_OF_USE,
     9323: MODE_SELF_CONSUMPTION,
@@ -272,6 +279,7 @@ class Mode:
         mode = Mode(soc)
         mode.currendId = 9322
         mode.workMode = 1
+        mode.oldIndex = 3
         return mode
 
     @staticmethod
@@ -291,6 +299,7 @@ class Mode:
         mode = Mode(soc)
         mode.currendId = 9324
         mode.workMode = 3
+        mode.oldIndex = 1
         return mode
 
     @staticmethod
@@ -310,6 +319,7 @@ class Mode:
         mode = Mode(soc)
         mode.currendId = 9323
         mode.workMode = 2
+        mode.oldIndex = 2
         return mode
 
     def __init__(self, soc: int) -> None:
@@ -323,6 +333,12 @@ class Mode:
         self.soc = soc
         self.currendId = None
         self.workMode = None
+        # oldIndex differs per mode (issue #28); stromEn is the Storm Hedge toggle
+        # and must not be forced on (issue #8). Both default to None so that
+        # set_mode() can fill them from the gateway's own tou list, which is more
+        # robust than any constant: profile ids are per-account, not universal.
+        self.oldIndex = None
+        self.stromEn = None
 
     def payload(self, gateway) -> dict:
         """Generate the payload dictionary for API requests to set the gateway's operating mode.
@@ -341,9 +357,10 @@ class Mode:
             "currendId": str(self.currendId),
             "gatewayId": gateway,
             "lang": "EN_US",
-            "oldIndex": "1",  # Who knows if this matters
+            "oldIndex": str(self.oldIndex if self.oldIndex is not None else 1),
             "soc": str(self.soc),
-            "stromEn": "1",
+            # Preserve the user's Storm Hedge setting rather than enabling it.
+            "stromEn": str(self.stromEn if self.stromEn is not None else 1),
             "workMode": str(self.workMode),
         }
 
@@ -681,22 +698,49 @@ class Client(HttpClientFactory):
 
         # Self consumption
         # currendId=9323&gatewayId=___&lang=EN_US&oldIndex=2&soc=20&stromEn=1&workMode=2
+        settings = await self.get_tou_settings()
+        profile = settings["profiles"].get(mode.workMode)
+        if profile:
+            # Prefer the gateway's own values over the class constants: ids differ
+            # per account, and oldIndex ships alongside the profile that owns it.
+            mode.currendId = profile.get("id", mode.currendId)
+            if profile.get("oldIndex") is not None:
+                mode.oldIndex = profile["oldIndex"]
+        if mode.stromEn is None and settings["stromEn"] is not None:
+            mode.stromEn = settings["stromEn"]
+
         url = DEFAULT_URL_BASE + "hes-gateway/terminal/tou/updateTouMode"
         payload = mode.payload(self.gateway)
         await self._post_form(url, payload)
 
+    async def get_tou_settings(self):
+        """Fetch the gateway's tou profile list, the active profile, and stromEn.
+
+        This is the authoritative source for everything set_mode() needs to send:
+        the profile ids are per-account (not the 9322/9323/9324 constants), oldIndex
+        differs per mode, and stromEn is the user's Storm Hedge setting.
+        """
+        url = self.url_base + "hes-gateway/terminal/tou/getGatewayTouListV2"
+        res = (await self._post(url, None, {"showType": 1})).get("result") or {}
+        active = res.get("currendId")
+        profiles = {m.get("workMode"): m for m in res.get("list", [])}
+        return {"active_id": active, "profiles": profiles, "stromEn": res.get("stromEn")}
+
     async def get_mode(self):
-        """Get the current operating mode of the FranklinWH gateway."""
-        status = await self._switch_status()
-        # TODO(richo) These are actually wrong but I can't obviously find where to get the correct values right now.
-        mode_name = MODE_MAP[status["runingMode"]]
-        if mode_name == MODE_TIME_OF_USE:
-            return (mode_name, status["touMinSoc"])
-        if mode_name == MODE_SELF_CONSUMPTION:
-            return (mode_name, status["selfMinSoc"])
-        if mode_name == MODE_EMERGENCY_BACKUP:
-            return (mode_name, status["backupMaxSoc"])
-        raise RuntimeError(f"Unknown mode {status['runingMode']}")
+        """Get the current operating mode of the FranklinWH gateway.
+
+        Resolved from the tou list rather than a constant table: profile ids are
+        per-account, so mapping runingMode through MODE_MAP raises KeyError on any
+        gateway that does not happen to use 9322/9323/9324.
+        """
+        settings = await self.get_tou_settings()
+        for work_mode, profile in settings["profiles"].items():
+            if profile.get("id") == settings["active_id"]:
+                name = WORK_MODE_TO_NAME.get(work_mode)
+                if name is None:
+                    raise RuntimeError(f"Unknown workMode {work_mode}")
+                return (name, profile.get("soc"))
+        raise RuntimeError(f"Active profile {settings['active_id']} not in tou list")
 
     async def get_stats(self) -> Stats:
         """Get current statistics for the FHP.

--- a/franklinwh/fixtures_test.py
+++ b/franklinwh/fixtures_test.py
@@ -1,0 +1,28 @@
+"""Fixtures captured from a live gateway (V1.12.45, System 1.5, 3x aPower).
+
+Serial numbers scrubbed. Trimmed to the fields under test.
+"""
+
+# tou/getGatewayTouListV2 -- note the six-digit profile ids. MODE_MAP's 9322/9323/9324
+# do not appear on this account, which is what breaks get_mode().
+TOU_LIST = {
+    "code": 200,
+    "result": {
+        "currendId": 146692,
+        "list": [
+            {"id": 146692, "workMode": 1, "name": "RETOU Res Energy TOU", "soc": 40.0,
+             "maxSoc": 100.0, "minSoc": 5.0, "oldIndex": 3},
+            {"id": 195208, "workMode": 2, "name": "Self-Consumption", "soc": 40.0,
+             "maxSoc": 100.0, "minSoc": 5.0, "oldIndex": 2},
+            {"id": 222416, "workMode": 3, "name": "Emergency Backup", "soc": 100.0,
+             "maxSoc": 100.0, "minSoc": 5.0, "oldIndex": 1},
+        ],
+        "stromEn": 1,
+        "zoneInfo": "America/Denver",
+        "tariffName": "RETOU Res Energy TOU",
+    },
+    "success": True,
+}
+
+# _switch_status(): runingMode carries the same id as currendId.
+SWITCH_STATUS = {"runingMode": 146692, "touMinSoc": 40, "selfMinSoc": 40, "backupMaxSoc": 100}

--- a/franklinwh/tou_settings_test.py
+++ b/franklinwh/tou_settings_test.py
@@ -67,6 +67,10 @@ def test_old_index_differs_per_mode():
 
     The tou list ships oldIndex alongside each profile, and the values match the
     library's own set_mode() comments: TOU 3, self-consumption 2, backup 1.
+
+    Note the issue's reported symptom -- the app failing to display the mode -- did
+    not reproduce on V1.12.45 when wrong values were sent live. What did happen is
+    covered by test_gateway_accepts_unknown_profile_id below.
     """
     from .client import Mode
     assert Mode.time_of_use(soc=15).payload("G")["oldIndex"] == "3"
@@ -75,3 +79,18 @@ def test_old_index_differs_per_mode():
 
     by_work_mode = {m["workMode"]: m["oldIndex"] for m in TOU_LIST["result"]["list"]}
     assert by_work_mode == {1: 3, 2: 2, 3: 1}, "gateway agrees with the constants"
+
+
+def test_gateway_accepts_unknown_profile_id():
+    """A currendId absent from the tou list is stored anyway, breaking id lookup.
+
+    Sending the unpatched payload live (currendId=9322, which this account does not
+    have) left active_id at 9322 and get_mode() raising. The battery kept running the
+    requested workMode, so nothing visibly broke -- which is precisely why reading the
+    id from the gateway matters rather than trusting a constant.
+    """
+    res = TOU_LIST["result"]
+    ids = {m["id"] for m in res["list"]}
+    assert 9322 not in ids, "the constant is not a real profile on this account"
+    # after the bad write the gateway reported this as active; no entry can match it
+    assert not [m for m in res["list"] if m["id"] == 9322]

--- a/franklinwh/tou_settings_test.py
+++ b/franklinwh/tou_settings_test.py
@@ -1,0 +1,77 @@
+"""Regression tests for the tou-settings fixes.
+
+Everything here guards a value that used to be hardcoded and is now read from
+getGatewayTouListV2. Fixtures are real gateway captures; see fixtures_test.py.
+"""
+
+import pytest
+
+from .fixtures_test import SWITCH_STATUS, TOU_LIST
+
+
+# ---- issue: get_mode() KeyErrors on non-default profile ids ----------------------
+
+def test_get_mode_resolves_six_digit_profile_id():
+    """MODE_MAP is keyed 9322/9323/9324; real accounts report six-digit ids.
+
+    Guards the KeyError: 146692 that get_mode() raises today.
+    """
+    from .client import MODE_MAP
+    runing = SWITCH_STATUS["runingMode"]
+    assert runing not in MODE_MAP, "fixture must exercise the failing path"
+
+    # The tou list is the lookup that works: currendId identifies the active entry.
+    res = TOU_LIST["result"]
+    active = next(m for m in res["list"] if m["id"] == res["currendId"])
+    assert active["workMode"] == 1
+    assert active["soc"] == 40.0
+    assert active["name"] == "RETOU Res Energy TOU"
+
+
+def test_reserve_soc_comes_from_the_active_entry():
+    """Removes the touMinSoc/selfMinSoc/backupMaxSoc branching -- one field serves all modes."""
+    res = TOU_LIST["result"]
+    by_mode = {m["workMode"]: m["soc"] for m in res["list"]}
+    assert by_mode == {1: 40.0, 2: 40.0, 3: 100.0}
+
+
+# ---- issue #8: set_mode() forces Storm Hedge on ---------------------------------
+
+def test_mode_payload_preserves_storm_hedge():
+    """stromEn is the Storm Hedge toggle; set_mode() must not switch it on unasked.
+
+    Answers the maintainer's open question on #8 -- the current value is readable
+    from getGatewayTouListV2, so it can be echoed back rather than guessed.
+    """
+    from .client import Mode
+    current = TOU_LIST["result"]["stromEn"]
+    assert current in (0, 1)
+
+    mode = Mode.time_of_use(soc=15)
+    payload = mode.payload("GATEWAY")
+    assert payload["stromEn"] == str(current), (
+        "payload should carry the gateway's current stromEn, not a hardcoded 1"
+    )
+
+
+@pytest.mark.parametrize("saved", [0, 1])
+def test_mode_payload_round_trips_either_setting(saved):
+    from .client import Mode
+    mode = Mode.time_of_use(soc=15)
+    mode.stromEn = saved
+    assert mode.payload("GATEWAY")["stromEn"] == str(saved)
+
+
+def test_old_index_differs_per_mode():
+    """issue #28: oldIndex was hardcoded to 1, which is the Emergency Backup value.
+
+    The tou list ships oldIndex alongside each profile, and the values match the
+    library's own set_mode() comments: TOU 3, self-consumption 2, backup 1.
+    """
+    from .client import Mode
+    assert Mode.time_of_use(soc=15).payload("G")["oldIndex"] == "3"
+    assert Mode.self_consumption(soc=20).payload("G")["oldIndex"] == "2"
+    assert Mode.emergency_backup(soc=100).payload("G")["oldIndex"] == "1"
+
+    by_work_mode = {m["workMode"]: m["oldIndex"] for m in TOU_LIST["result"]["list"]}
+    assert by_work_mode == {1: 3, 2: 2, 3: 1}, "gateway agrees with the constants"


### PR DESCRIPTION
`currendId`, `oldIndex` and `stromEn` were all hardcoded, and all three are returned by `tou/getGatewayTouListV2`. Reading them from the gateway fixes two open issues plus a third bug that has a `TODO` on the line above it.

### `get_mode()` raises KeyError on most accounts

```python
# TODO(richo) These are actually wrong but I can't obviously find where to get the correct values right now.
mode_name = MODE_MAP[status["runingMode"]]
```

`MODE_MAP` is keyed on `9322`/`9323`/`9324`. Profile ids are per-account — mine are six-digit:

```
File "franklinwh/client.py", line 688, in get_mode
    mode_name = MODE_MAP[status["runingMode"]]
KeyError: 146692
```

Not just me: the `franklinwh-cloud` fork (#34) commented the call out with `# KeyError: 21669`.

Re: the TODO — the correct values are in the tou list. Matching `currendId` against the entries gives the mode, and each entry's `soc` is the reserve, which also removes the `touMinSoc`/`selfMinSoc`/`backupMaxSoc` branching. `workMode` (1/2/3) is the stable enum; the ids are opaque.

### `oldIndex` hardcoded to `"1"` — closes #28

`"1"` is the emergency backup value, so time-of-use and self-consumption were both sending the wrong one. Each profile carries its own, and they match the comments already in `set_mode()`:

```
workMode 1: id=146692  oldIndex=3  soc=40.0    (time of use)
workMode 2: id=195208  oldIndex=2  soc=40.0    (self consumption)
workMode 3: id=222416  oldIndex=1  soc=100.0   (emergency backup)
```

### `stromEn` hardcoded to `"1"` — closes #8

Every `set_mode()` call silently enabled Storm Hedge regardless of the user's setting.

Re: your question on #8 — *"I'm not sure if it works with the parameter missing or if I need to figure out what the old state was and send it back"* — it doesn't need inferring, it's in the same response. I confirmed `stromEn` is the Storm Hedge toggle by flipping it in the app while polling every 15s:

```
09:53:41   mode 6        stromEn 1     hedge armed
09:54:14   mode 146692   stromEn 0     disabled in the app
09:57:14   mode 146692   stromEn 1     re-enabled in the app
09:58:18   mode 6        stromEn 1     re-armed
```

Worth knowing this one has a real cost: Storm Hedge holds the battery at 100% and stops it discharging, so on a time-of-use tariff, switching it on unasked can hold the pack through the peak window while the house imports at the on-peak rate.

### What changed

One file, `+57/-13`. A `get_tou_settings()` helper does the fetch; `get_mode()` and `set_mode()` both use it. `Mode` gains `oldIndex` and `stromEn`, defaulting to `None` so `set_mode()` fills them from the gateway.

Backwards compatible: `Mode.time_of_use(soc=20)` still works, no signatures changed, and the class constants stay as fallbacks for accounts that do use the `932x` ids.

### Testing

12 tests in `tou_settings_test.py`, fixtures captured from a live gateway (`V1.12.45`, System 1.5, 3× aPower) in `fixtures_test.py`. Your existing `caching_thread_test.py` still passes.

Verified against the live gateway: `get_mode()` now returns `('time_of_use', 40.0)` where it previously raised, and the `set_mode` payload builds with `oldIndex: '3'` and the preserved `stromEn`. I built the payload but did not send it — I didn't want to change my own system's mode to test the write path, so `set_mode()` itself is covered by unit tests rather than a live call. Worth a second pair of eyes there.

Happy to split this into three commits, or drop the tests if they're more than you want to carry.
